### PR TITLE
- Fix error downloading from servers that offer modern TLS only (requ…

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ _Yet Another Favicon Downloader_ (_YAFD_ for short) is a plugin for _KeePass_ 2.
 
 ### Linux
 
-- _Mono_ 2.10.8 or newer.
+- _Mono_ 4.0 or newer.
 
 ### Windows
 
-- _.NET Framework_ 2.0 or newer.
+- _.NET Framework_ 4.5 or newer.
 
 ## Installation
 

--- a/YAFD/Properties/Resources.Designer.cs
+++ b/YAFD/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace YetAnotherFaviconDownloader.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/YAFD/YetAnotherFaviconDownloader.csproj
+++ b/YAFD/YetAnotherFaviconDownloader.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>YetAnotherFaviconDownloader</RootNamespace>
     <AssemblyName>YetAnotherFaviconDownloader</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -21,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>ISO-2</LangVersion>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="KeePass">


### PR DESCRIPTION
…ired increasing .NET framework requirement to 4.5)

- Support rel="icon shortcut" as seen on a few websites
- Use URL after redirection as the base for image requests
- Allow more redirections (4 not enough for some sites)
- Don't fail completely if first favicon request fails, instead continue to try all remaining links